### PR TITLE
Robustify the checker a bit

### DIFF
--- a/src/cmd/testcheck/main.go
+++ b/src/cmd/testcheck/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/opsee/bastion/checker"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+func main() {
+	addr := os.Args[1]
+	clientConn, err := grpc.Dial(addr)
+	if err != nil {
+		panic(err)
+	}
+
+	cc := checker.NewCheckerClient(clientConn)
+
+	check := &checker.HttpCheck{
+		Name:     "test",
+		Path:     "/health_check",
+		Protocol: "http",
+		Port:     8080,
+		Verb:     "GET",
+	}
+	checkSpec, err := checker.MarshalAny(check)
+	if err != nil {
+		panic(err)
+	}
+
+	testCheckRequest := &checker.TestCheckRequest{
+		MaxHosts: 1,
+		Deadline: &checker.Timestamp{
+			Seconds: time.Now().Add(time.Duration(30) * time.Second).Unix(),
+		},
+		Check: &checker.Check{
+			Target: &checker.Target{
+				Id:   "api-lb",
+				Name: "api-lb",
+				Type: "elb",
+			},
+			CheckSpec: checkSpec,
+		},
+	}
+
+	response, err := cc.TestCheck(context.Background(), testCheckRequest)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(response)
+}

--- a/src/github.com/opsee/bastion/checker/checker_test.go
+++ b/src/github.com/opsee/bastion/checker/checker_test.go
@@ -20,7 +20,7 @@ const (
 var (
 	testChecker       *Checker
 	testCheckerClient *CheckerRpcClient
-	testContext       = context.TODO()
+	testContext       = context.Background()
 
 	requestStub = &TestCheckRequest{
 		MaxHosts: 1,
@@ -188,6 +188,32 @@ func TestTimeoutTestCheck(t *testing.T) {
 	}
 
 	if response != nil {
+		t.Fail()
+	}
+
+	teardown(t)
+}
+
+func TestCheckerTestCheckWithMaxHosts(t *testing.T) {
+	setup(t)
+
+	target := &Target{
+		Type: "sg",
+		Id:   "sg3",
+	}
+
+	request, err := buildTestCheckRequest(httpCheckStub(), target)
+	if err != nil {
+		t.Fatalf("Unable to build test check request: target = %s, check stub = %s", target, request)
+	}
+
+	response, err := testCheckerClient.Client.TestCheck(testContext, request)
+
+	if err != nil {
+		t.Fail()
+	}
+
+	if response == nil {
 		t.Fail()
 	}
 

--- a/src/github.com/opsee/bastion/checker/common_test.go
+++ b/src/github.com/opsee/bastion/checker/common_test.go
@@ -32,8 +32,8 @@ func testCheckStub() *Check {
 }
 
 type testResolver struct {
-	t map[string][]*Target
-	i map[string][]*string
+	Targets   map[string][]*Target
+	Instances map[string][]*string
 }
 
 func (t *testResolver) Resolve(tgt *Target) ([]*Target, error) {
@@ -41,11 +41,11 @@ func (t *testResolver) Resolve(tgt *Target) ([]*Target, error) {
 	if tgt.Id == "empty" {
 		return []*Target{}, nil
 	}
-	return t.t[tgt.Id], nil
+	return t.Targets[tgt.Id], nil
 }
 
 func (t *testResolver) ResolveInstance(instanceId string) ([]*string, error) {
-	resolved := t.i[instanceId]
+	resolved := t.Instances[instanceId]
 	if resolved == nil {
 		return nil, fmt.Errorf("Unable to resolve target: %v", instanceId)
 	}
@@ -56,15 +56,32 @@ func newTestResolver() *testResolver {
 	addr := "127.0.0.1"
 	addrPtr := &addr
 	return &testResolver{
-		t: map[string][]*Target{
+		Targets: map[string][]*Target{
 			"sg": []*Target{
 				&Target{
 					Id:   "id",
 					Type: "instance",
 				},
 			},
+			"sg3": []*Target{
+				&Target{
+					Id:   "id",
+					Name: "id",
+					Type: "instance",
+				},
+				&Target{
+					Id:   "id",
+					Name: "id",
+					Type: "instance",
+				},
+				&Target{
+					Id:   "id",
+					Name: "id",
+					Type: "instance",
+				},
+			},
 		},
-		i: map[string][]*string{
+		Instances: map[string][]*string{
 			"id": []*string{addrPtr},
 		},
 	}


### PR DESCRIPTION
Recover from panics in the runner, because if the context is
canceled, we may try to do something that causes a panic. It's okay
to do this, in my opinion as there are some things that are hard
to detect.
