### PR TITLE
"Refactor" the dispatcher and workers

### DIFF
--- a/src/github.com/opsee/bastion/checker/checker.go
+++ b/src/github.com/opsee/bastion/checker/checker.go
@@ -132,7 +132,6 @@ func (c *Checker) TestCheck(ctx context.Context, req *TestCheckRequest) (*TestCh
 	ctx = context.WithValue(ctx, "MaxHosts", int(req.MaxHosts))
 
 	responses := c.Runner.RunCheck(ctx, req.Check)
-	defer close(responses)
 
 	testCheckResponse := &TestCheckResponse{
 		Responses: make([]*CheckResponse, req.MaxHosts),

--- a/src/github.com/opsee/bastion/checker/common_test.go
+++ b/src/github.com/opsee/bastion/checker/common_test.go
@@ -27,6 +27,13 @@ func (t TestCommonStubs) HTTPCheck() *HttpCheck {
 	}
 }
 
+func (t TestCommonStubs) HTTPRequest() *HTTPRequest {
+	return &HTTPRequest{
+		Method: "GET",
+		URL:    fmt.Sprintf("http://127.0.0.1:%d/", testHTTPServerPort),
+	}
+}
+
 func (t TestCommonStubs) Check() *Check {
 	return &Check{
 		Id:        "string",
@@ -42,6 +49,19 @@ func (t TestCommonStubs) PassingCheck() *Check {
 		Type: "sg",
 		Id:   "sg",
 		Name: "sg",
+	}
+
+	spec, _ := MarshalAny(t.HTTPCheck())
+	check.CheckSpec = spec
+	return check
+}
+
+func (t TestCommonStubs) PassingCheckMultiTarget() *Check {
+	check := t.Check()
+	check.Target = &Target{
+		Type: "sg",
+		Id:   "sg3",
+		Name: "sg3",
 	}
 
 	spec, _ := MarshalAny(t.HTTPCheck())

--- a/src/github.com/opsee/bastion/checker/dispatcher_test.go
+++ b/src/github.com/opsee/bastion/checker/dispatcher_test.go
@@ -1,0 +1,120 @@
+package checker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"golang.org/x/net/context"
+)
+
+type dispatcherTestWorkerRequest struct{}
+type dispatcherTestWorker struct {
+	WorkerQueue chan Worker
+}
+
+func (w *dispatcherTestWorkerRequest) Do() *Response {
+	return &Response{}
+}
+func newDispatcherTestWorker(c chan Worker) Worker {
+	return &dispatcherTestWorker{
+		WorkerQueue: c,
+	}
+}
+func (w *dispatcherTestWorker) Work(t *Task) *Task {
+	t.Response = t.Request.Do()
+	return t
+}
+
+type DispatcherTestSuite struct {
+	suite.Suite
+	Common      TestCommonStubs
+	Dispatcher  *Dispatcher
+	Context     context.Context
+	MultiTaskTG TaskGroup
+	EmptyTG     TaskGroup
+}
+
+func (s *DispatcherTestSuite) SetupTest() {
+	s.Dispatcher = NewDispatcher()
+	s.Context = context.Background()
+	RegisterWorker("dispatcherTestWorkerRequest", newDispatcherTestWorker)
+	s.MultiTaskTG = TaskGroup{
+		&Task{Type: "dispatcherTestWorkerRequest", Request: new(dispatcherTestWorkerRequest)},
+		&Task{Type: "dispatcherTestWorkerRequest", Request: new(dispatcherTestWorkerRequest)},
+		&Task{Type: "dispatcherTestWorkerRequest", Request: new(dispatcherTestWorkerRequest)},
+	}
+	s.EmptyTG = TaskGroup{}
+}
+
+func (s *DispatcherTestSuite) TestDispatchClosesFinishedChannel() {
+	tg := s.EmptyTG
+	finished := s.Dispatcher.Dispatch(s.Context, tg)
+	select {
+	case _, ok := <-finished:
+		assert.False(s.T(), ok)
+	case <-time.After(time.Duration(1) * time.Second):
+		assert.Fail(s.T(), "Dispatcher.Dispatch did not close channel.")
+	}
+}
+
+func (s *DispatcherTestSuite) TestDispatchEmptyTaskGroup() {
+	tg := s.EmptyTG
+	finished := s.Dispatcher.Dispatch(s.Context, tg)
+	done := TaskGroup{}
+	for ft := range finished {
+		done = append(done, ft)
+	}
+	assert.Len(s.T(), tg, 0)
+}
+
+func (s *DispatcherTestSuite) TestDispatchTaskGroup() {
+	tg := s.MultiTaskTG
+
+	finished := s.Dispatcher.Dispatch(s.Context, tg)
+	done := TaskGroup{}
+	for ft := range finished {
+		done = append(done, ft)
+	}
+	assert.Len(s.T(), done, 3)
+	for _, t := range done {
+		assert.IsType(s.T(), new(Task), t)
+		assert.NotNil(s.T(), t.Response)
+	}
+}
+
+func (s *DispatcherTestSuite) TestDispatchWithDeadlineExceeded() {
+	tg := s.MultiTaskTG
+	ctx, _ := context.WithDeadline(s.Context, time.Now())
+	finished := s.Dispatcher.Dispatch(ctx, tg)
+	done := TaskGroup{}
+	for ft := range finished {
+		done = append(done, ft)
+	}
+	assert.Len(s.T(), done, 3)
+	for _, t := range done {
+		assert.IsType(s.T(), new(Task), t)
+		assert.NotNil(s.T(), t.Response.Error)
+	}
+}
+
+func (s *DispatcherTestSuite) TestDispatchWithCancelledContext() {
+	tg := s.MultiTaskTG
+	ctx, cancel := context.WithCancel(s.Context)
+	cancel()
+	finished := s.Dispatcher.Dispatch(ctx, tg)
+	done := TaskGroup{}
+	for ft := range finished {
+		done = append(done, ft)
+	}
+	assert.Len(s.T(), done, 3)
+	for _, t := range done {
+		assert.IsType(s.T(), new(Task), t)
+		assert.NotNil(s.T(), t.Response.Error)
+	}
+}
+
+func TestDispatcherTestSuite(t *testing.T) {
+	suite.Run(t, new(DispatcherTestSuite))
+}

--- a/src/github.com/opsee/bastion/checker/runner_test.go
+++ b/src/github.com/opsee/bastion/checker/runner_test.go
@@ -1,19 +1,32 @@
 package checker
 
 import (
-	// "net/http"
 	"testing"
 
-	// "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/net/context"
 )
 
 type RunnerTestSuite struct {
 	suite.Suite
+	Common TestCommonStubs
+	Runner *Runner
 }
 
-func (s *RunnerTestSuite) RunCheckMultipleTargets() {
+func (s *RunnerTestSuite) SetupTest() {
+	s.Runner = NewRunner(newTestResolver())
+}
 
+func (s *RunnerTestSuite) TestRunCheckMultipleTargets() {
+	check := s.Common.PassingCheckMultiTarget()
+	responses := s.Runner.RunCheck(context.Background(), check)
+	count := 0
+	for response := range responses {
+		count++
+		assert.IsType(s.T(), new(CheckResponse), response)
+	}
+	assert.Equal(s.T(), count, 3)
 }
 
 func TestRunnerTestSuite(t *testing.T) {

--- a/src/github.com/opsee/bastion/checker/worker.go
+++ b/src/github.com/opsee/bastion/checker/worker.go
@@ -18,11 +18,14 @@ type Task struct {
 	Target   *Target
 	Request  Request
 	Response *Response
-	Finished chan *Task
 }
 
 type Worker interface {
-	Work()
+	Work(*Task) *Task
 }
 
-type NewWorkerFunc func(workQueue chan *Task) Worker
+type NewWorkerFunc func(chan Worker) Worker
+
+func RegisterWorker(workerType string, newFun NewWorkerFunc) {
+	Recruiters[workerType] = newFun
+}


### PR DESCRIPTION
Instead of asynchronous everything all the time, which needlessly
complicates a number of things, we simplify the dispatcher and
workers in order to make things a bit more predictable.

This commit also adds a hopefully reasonable amount of testing to
ensure the Dispatcher adheres to its new contract.
