### PR TITLE
all of our units should just wait for the user-config target before starting

### DIFF
--- a/build/bastion-etcd.service
+++ b/build/bastion-etcd.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Bastion Etcd
-After=docker.service
-Requires=docker.service
+After=user-config.target docker.service
+Requires=user-config.target docker.service
 
 [Service]
 Restart=always

--- a/build/checker.service
+++ b/build/checker.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Bastion - Checker
-After=docker.service nsqd.service connector.service
-Requires=docker.service nsqd.service connector.service
+After=user-config.target docker.service nsqd.service connector.service
+Requires=user-config.target docker.service nsqd.service connector.service
 PartOf=connector.service
 
 [Service]

--- a/build/connector.service
+++ b/build/connector.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Bastion - Connector
-After=docker.service
-Requires=docker.service
+After=user-config.target docker.service
+Requires=user-config.target docker.service
 
 [Service]
 EnvironmentFile=/etc/opsee/bastion-env.sh

--- a/build/discovery.service
+++ b/build/discovery.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Bastion - Discovery
-After=docker.service nsqd.service
-Requires=docker.service nsqd.service
+After=user-config.target docker.service nsqd.service
+Requires=user-config.target docker.service nsqd.service
 
 [Service]
 Restart=always

--- a/build/hacker.service
+++ b/build/hacker.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Bastion - Security Group Hack
-After=docker.service
-Requires=docker.service
+After=user-config.target docker.service
+Requires=user-config.target docker.service
 
 [Service]
 Restart=always

--- a/build/monitor.service
+++ b/build/monitor.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Bastion - Monitor
-After=docker.service nsqd.service
-Requires=docker.service nsqd.service
+After=user-config.target docker.service nsqd.service
+Requires=user-config.target docker.service nsqd.service
 
 [Service]
 Restart=always

--- a/build/nsqadmin.service
+++ b/build/nsqadmin.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=nsqadmin
-After=docker.service nsqd.service
-Requires=docker.service nsqd.service
+After=user-config.target docker.service nsqd.service
+Requires=user-config.target docker.service nsqd.service
 
 [Service]
 Restart=always

--- a/build/nsqd.service
+++ b/build/nsqd.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=nsqd
-After=docker.service
-Requires=docker.service
+After=user-config.target docker.service
+Requires=user-config.target docker.service
 
 [Service]
 Restart=always

--- a/build/register.service
+++ b/build/register.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Bastion - Registration
-After=docker.service connector.service
-Requires=docker.service connector.service
+After=user-config.target docker.service connector.service
+Requires=user-config.target docker.service connector.service
 PartOf=connector.service
 
 [Service]

--- a/build/runner.service
+++ b/build/runner.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Bastion - Check Runner
-After=docker.service nsqd.service
-Requires=docker.service nsqd.service
+After=user-config.target docker.service nsqd.service
+Requires=user-config.target docker.service nsqd.service
 
 [Service]
 Restart=always

--- a/build/shovel-discovery.service
+++ b/build/shovel-discovery.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=NSQ Shovel: Discovery
-After=docker.service nsqd.service connector.service
-Requires=docker.service nsqd.service connector.service
+After=user-config.target docker.service nsqd.service connector.service
+Requires=user-config.target docker.service nsqd.service connector.service
 PartOf=connector.service
 
 [Service]

--- a/build/shovel-results.service
+++ b/build/shovel-results.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=NSQ Shovel: Results
-After=docker.service nsqd.service connector.service
-Requires=docker.service nsqd.service connector.service
+After=user-config.target docker.service nsqd.service connector.service
+Requires=user-config.target docker.service nsqd.service connector.service
 PartOf=connector.service
 
 [Service]


### PR DESCRIPTION
Technically not all of these services need to wait for user-config, but it seems like making it a practice is a good idea, so I've included it in all of the unit files.
