### PR TITLE
Add unhacker.  Take a random walk across systemd units

### DIFF
--- a/build/checker.service
+++ b/build/checker.service
@@ -13,7 +13,7 @@ EnvironmentFile=/etc/opsee/bastion-env.sh
 ExecStartPre=-/usr/bin/docker stop -t 5 %p
 ExecStartPre=-/usr/bin/docker rm %p
 ExecStartPre=/usr/bin/docker pull quay.io/opsee/bastion:${BASTION_VERSION}
-ExecStart=/usr/bin/docker run --name %p --net="container:connector" --device=/dev/net/tun --env-file /etc/opsee/bastion-env.sh quay.io/opsee/bastion:${BASTION_VERSION} /checker
+ExecStart=/usr/bin/docker run --name %p --net=container:connector --device=/dev/net/tun -e ETCD_HOST=etcd:2379 -e NSQD_HOST=nsqd:4150 --env-file /etc/opsee/bastion-env.sh quay.io/opsee/bastion:${BASTION_VERSION} /checker
 ExecStop=/usr/bin/docker stop -t 5 %p
 
 [Install]

--- a/build/discovery.service
+++ b/build/discovery.service
@@ -1,12 +1,12 @@
 [Unit]
 Description=Bastion - Discovery
-After=env-lock.service docker.service nsqd.service
-Requires=env-lock.service docker.service nsqd.service
+After=env-lock.service docker.service nsqd.service hacker.service
+Requires=env-lock.service docker.service nsqd.service hacker.service
 
 [Service]
 Restart=always
 User=core
-TimeoutStartSec=0
+TimeoutStartSec=5s
 EnvironmentFile=/etc/opsee/bastion-env.sh
 ExecStartPre=-/usr/bin/docker stop -t 5 %p
 ExecStartPre=-/usr/bin/docker rm %p

--- a/build/hacker.service
+++ b/build/hacker.service
@@ -1,17 +1,17 @@
 [Unit]
 Description=Bastion - Security Group Hack
-After=env-lock.service docker.service
-Requires=env-lock.service docker.service
+After=env-lock.service docker.service connector.service
+Requires=env-lock.service docker.service connector.service
 
 [Service]
-Restart=always
+Type=oneshot
 User=core
-TimeoutStartSec=0
 EnvironmentFile=/etc/opsee/bastion-env.sh
 ExecStartPre=-/usr/bin/docker stop -t 5 %p
 ExecStartPre=-/usr/bin/docker rm %p
 ExecStartPre=/usr/bin/docker pull quay.io/opsee/bastion:${BASTION_VERSION}
 ExecStart=/usr/bin/docker run --name %p quay.io/opsee/bastion:${BASTION_VERSION} /hacker
+
 ExecStop=/usr/bin/docker stop -t 5 %p
 
 [Install]

--- a/build/mami.json
+++ b/build/mami.json
@@ -1,8 +1,8 @@
 {
     "regions": "all",
     "copy-to": "all",
-    "build-region": "us-west-1",
-    "source-ami": "ami-41bc7d05",
+    "build-region": "us-east-1",
+    "source-ami": "ami-3f733b5a",
     "ami-name": "Opsee-Bastion-{{clean-timestamp}}",
     "ami-description": "Opsee's Bastion Software",
     "instance-type":"t2.micro",
@@ -66,7 +66,7 @@
             "type":"systemd",
             "unit-file":"build/hacker.service"
         },
-        {
+         {
             "type":"systemd",
             "unit-file":"build/shovel-discovery.service"
         },
@@ -79,14 +79,14 @@
             "test":"-n \"$(curl -s --retry 10 --retry-delay 5 http://localhost:4001/health_check)\""
         },
         {
-            "type": "shell",
-            "instructions":["sudo rm -f /etc/opsee/bastion-env.sh"]
+            "type":"systemd",
+            "unit-file":"build/unhacker.service"
         }
     ],
     "reboot-before-build": false,
     "public": false,
-    "cleanup": true
+    "cleanup": false
         {{#ci}}
-        ,"cleanup-on-error": true
+        ,"cleanup-on-error": false
         {{/ci}}
 }

--- a/build/monitor.service
+++ b/build/monitor.service
@@ -6,10 +6,9 @@ Requires=env-lock.service docker.service nsqd.service connector.service
 [Service]
 Restart=always
 User=core
-TimeoutStartSec=0
+TimeoutStartSec=5s
 Environment="NSQD_HOST=127.0.0.1:4150"
 EnvironmentFile=/etc/opsee/bastion-env.sh
-StartLimitInterval=0
 ExecStartPre=-/usr/bin/docker stop -t 5 %p
 ExecStartPre=-/usr/bin/docker rm %p
 ExecStartPre=/usr/bin/docker pull quay.io/opsee/bastion:${BASTION_VERSION}

--- a/build/register.service
+++ b/build/register.service
@@ -9,6 +9,7 @@ Restart=always
 EnvironmentFile=/etc/opsee/bastion-env.sh
 User=core
 TimeoutStartSec=0
+StartLimitInterval=0
 ExecStartPre=-/usr/bin/docker stop -t 5 %p
 ExecStartPre=-/usr/bin/docker rm %p
 ExecStartPre=/usr/bin/docker pull quay.io/opsee/zuul:latest

--- a/build/unhacker.service
+++ b/build/unhacker.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Bastion - Security Group Unhacker
+Before=shutdown.target reboot.target halt.target
+
+[Service]
+Type=oneshot
+User=core
+TimeoutStopSec=0
+EnvironmentFile=/etc/opsee/bastion-env.sh
+ExecStart=/bin/true
+ExecStop=/usr/bin/docker stop -t 5 hacker
+ExecStop=/usr/bin/docker run --name %p quay.io/opsee/bastion:${BASTION_VERSION} /hacker -unhack
+ExecStopPost=/usr/bin/docker stop -t 5 %p
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target

--- a/src/cmd/hacker/main.go
+++ b/src/cmd/hacker/main.go
@@ -1,29 +1,40 @@
 package main
 
 import (
+	"flag"
 	"io/ioutil"
 	"net/http"
+	"os"
+	"os/signal"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/opsee/awscan"
 	"github.com/opsee/bastion/config"
-	"github.com/opsee/bastion/logging"
+	"github.com/opsee/bastion/heart"
+)
+
+var (
+	moduleName    = "hacker"
+	unhackFlagPtr = flag.Bool("unhack", false, "detach from security groups")
+	sgidFlagStr   = flag.String("sgid", "none", "id of the security group")
+	bastionSgId   = aws.String("none")
+	sigs          = make(chan os.Signal, 1)
+	httpClient    = &http.Client{}
+	ec2Client     = &ec2.EC2{}
+	heartbeat     = &heart.Heart{}
+	sc            awscan.EC2Scanner
 )
 
 func main() {
-	logger := logging.GetLogger("hacker")
+	signal.Notify(sigs, os.Interrupt, os.Kill)
+
 	cfg := config.GetConfig()
-
-	sc := awscan.NewScanner(&awscan.Config{AccessKeyId: cfg.AccessKeyId, SecretKey: cfg.SecretKey, Region: cfg.MetaData.Region})
-
-	httpClient := &http.Client{}
-	metap := config.NewMetadataProvider(httpClient, cfg)
-	metadata := metap.Get()
-	region := metadata.Region
+	sc = awscan.NewScanner(&awscan.Config{AccessKeyId: cfg.AccessKeyId, SecretKey: cfg.SecretKey, Region: cfg.MetaData.Region})
 
 	var creds = credentials.NewChainCredentials(
 		[]credentials.Provider{
@@ -36,86 +47,137 @@ func main() {
 			&ec2rolecreds.EC2RoleProvider{ExpiryWindow: 5 * time.Minute},
 		})
 
-	awsConfig := &aws.Config{Credentials: creds, Region: aws.String(region)}
+	awsConfig := &aws.Config{Credentials: creds, Region: aws.String(cfg.MetaData.Region)}
+	ec2Client = ec2.New(awsConfig)
 
-	ec2Client := ec2.New(awsConfig)
-
-	resp, err := httpClient.Get("http://169.254.169.254/latest/meta-data/security-groups/")
+	var err error
+	heartbeat, err = heart.NewHeart(moduleName)
 	if err != nil {
-		logger.Error(err.Error())
-		logger.Fatal("Unable to get security group from meta data service")
+		log.Fatal(err.Error())
 	}
 
-	defer resp.Body.Close()
-	secGroupName, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		logger.Fatal(err.Error())
-	}
-
-	output, err := ec2Client.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
-		Filters: []*ec2.Filter{
-			&ec2.Filter{
-				Name: aws.String("group-name"),
-				Values: []*string{
-					aws.String(string(secGroupName)),
-				},
-			},
-		},
-	})
-
-	if len(output.SecurityGroups) != 1 {
-		logger.Fatal("Bad number of bastion security groups found: %d", len(output.SecurityGroups))
-	}
-
-	bastionSgId := output.SecurityGroups[0].GroupId
-
-	var found bool
-
+	// loop until sigkill
 	for {
-		sgs, err := sc.ScanSecurityGroups()
-		if err != nil {
-			logger.Error(err.Error())
-		}
+		// get the bastion's security group
+		aws.String(*sgidFlagStr)
 
-		for _, sg := range sgs {
-			logger.Debug("Found security group: %v", *sg)
-			found = false
-			for _, perm := range sg.IpPermissions {
-				for _, ipr := range perm.IpRanges {
-					if ipr.CidrIp == bastionSgId {
-						found = true
-					}
-				}
+		// if no security group was passed in, get one
+		if *bastionSgId == "none" {
+			resp, err := httpClient.Get("http://169.254.169.254/latest/meta-data/security-groups/")
+			if err != nil {
+				log.Error(err.Error())
+				log.Fatal("Unable to get security group from meta data service")
 			}
 
-			if !found {
-				_, err := ec2Client.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
-					GroupId: sg.GroupId,
-					IpPermissions: []*ec2.IpPermission{
-						&ec2.IpPermission{
-							IpProtocol: aws.String("-1"),
-							FromPort:   aws.Int64(0),
-							ToPort:     aws.Int64(65535),
-							UserIdGroupPairs: []*ec2.UserIdGroupPair{
-								&ec2.UserIdGroupPair{
-									GroupId: bastionSgId,
-								},
-							},
+			defer resp.Body.Close()
+			secGroupName, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				log.Fatal(err.Error())
+			}
+
+			output, err := ec2Client.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+				Filters: []*ec2.Filter{
+					&ec2.Filter{
+						Name: aws.String("group-name"),
+						Values: []*string{
+							aws.String(string(secGroupName)),
 						},
 					},
-				})
-				if err != nil {
-					logger.Error("Unable to add ourselves to security group: %s", *sg.GroupId)
-					logger.Error(err.Error())
-				} else {
-					logger.Info("Added ourselves to security group: %s", *sg.GroupId)
-				}
+				},
+			})
+
+			if len(output.SecurityGroups) != 1 {
+				log.Fatal("Bad number of bastion security groups found: %d", len(output.SecurityGroups))
 			}
-			// Janky, but in order to space out our requests, slow us down some.
-			time.Sleep(1 * time.Second)
+
+			bastionSgId = output.SecurityGroups[0].GroupId
 		}
 
-		// Only run this every half hour.
-		time.Sleep(30 * time.Minute)
+		log.Info(*bastionSgId)
+
+		// either hack or unhack
+		hack(*unhackFlagPtr, *bastionSgId)
+
+		if *unhackFlagPtr {
+			break
+		}
+
+		// hack to get the signal and run unhack
+		select {
+		case s := <-sigs:
+			log.Info("Received signal %s.  Stopping...", s)
+			os.Exit(0)
+		case <-time.After(25 * time.Minute):
+			continue
+		}
+	}
+}
+
+func hack(unhack bool, sgid string) {
+	var found bool
+
+	ippermission := []*ec2.IpPermission{
+		&ec2.IpPermission{
+			IpProtocol: aws.String("-1"),
+			FromPort:   aws.Int64(0),
+			ToPort:     aws.Int64(65535),
+			UserIdGroupPairs: []*ec2.UserIdGroupPair{
+				&ec2.UserIdGroupPair{
+					GroupId: bastionSgId,
+				},
+			},
+		}}
+
+	sgs, err := sc.ScanSecurityGroups()
+
+	if err != nil {
+		log.Error(err.Error())
+	}
+
+	for _, sg := range sgs {
+		found = false
+		for _, perm := range sg.IpPermissions {
+			for _, ipr := range perm.IpRanges {
+				if ipr.CidrIp == bastionSgId {
+					found = true
+				}
+			}
+		}
+
+		// Add ourselves to the security group, we're not in it yet
+		if !unhack && !found {
+			_, err := ec2Client.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
+				GroupId:       sg.GroupId,
+				IpPermissions: ippermission,
+			})
+			if err != nil {
+				log.Error("Unable to add ourselves to security group: ", *sg.GroupId)
+				log.Error(err.Error())
+			} else {
+				log.Info("Added ourselves to security group: ", *sg.GroupId)
+			}
+		}
+
+		// remove ourselves from the security group
+		if unhack {
+			_, err := ec2Client.RevokeSecurityGroupIngress(&ec2.RevokeSecurityGroupIngressInput{
+				GroupId:       sg.GroupId,
+				IpPermissions: ippermission,
+			})
+			if err != nil {
+				log.Error("Unable to remove ourselves to security group: ", *sg.GroupId)
+				log.Error(err.Error())
+			} else {
+				log.Info("Removed ourselves from security group: ", *sg.GroupId)
+			}
+		}
+
+		select {
+		case s := <-sigs:
+			log.Info("Received signal %s.  Stopping...", s)
+			os.Exit(0)
+		case <-time.After(500 * time.Millisecond):
+			continue
+		}
 	}
 }


### PR DESCRIPTION
added wait time to discovery to prevent us from hitting api limits

updated mami

added execstoppost for unhack, and fixed hacker

added flag for security group id and region for override

added ability to remove security groups locally, tested unhacker

add unhacker service to run at shutdown time

removed unhacker unit in favor of putting unhack in ExecStop

updated checker unit

can't use links with --net

updated hacker

make unhacker exit(0) when done)

remove startlimit interval to prevent builds from failing due to intermittant etcd issues (assumption)

removed timelimitstartsec

switch to us-west-1

stop fucking stopping the instances mami

change hacker to oneshot and remainafterexit=true such that the unhacking can finish
discovery now depends on hacker.service, hacker.service now requires connector.service

we can go back to east now that I fixed the mami bug locally

removed call to unhack from within hacker.  revert to unit

add dep for unhacker.service, change it's name

varname

remove startlimit

unhacker now appears to be working locally.

now that we know unhack is working, call it when hacker gets a signal

restart hacker only on-failure

unhacker.service change

[removed unhacker entirely] dangerously programming with permutation

updated WantedBy target in unhacker

mother. fucker.

removed erroneous var

let the conflict handle hacker shutdown

Add User=core so unhacker can download bastion image

more permutations

asdfasdf

asdf3

last test before trying to move unhacker into hacker.  remove After=shutdown.target.  Unhacker _should_ run after shutdown.target

Before=shutdown.target

asdf

unhacker can no longer timeout

don't remove env.sh

syntax

unhacker stops hacker prior to run

make hacker wait 30 minutes before adding again

Can't have an execstartpre

permute
