### PR TITLE
Add Missing http:// to etcd so that Checker.service can connect and register itself

### DIFF
--- a/build/checker.service
+++ b/build/checker.service
@@ -9,11 +9,12 @@ Restart=always
 User=core
 TimeoutStartSec=0
 RestartSec=5s
+Environment="NSQD_HOST=127.0.0.1:4150"
 EnvironmentFile=/etc/opsee/bastion-env.sh
 ExecStartPre=-/usr/bin/docker stop -t 5 %p
 ExecStartPre=-/usr/bin/docker rm %p
 ExecStartPre=/usr/bin/docker pull quay.io/opsee/bastion:${BASTION_VERSION}
-ExecStart=/usr/bin/docker run --name %p --net=container:connector --device=/dev/net/tun -e ETCD_HOST=etcd:2379 -e NSQD_HOST=nsqd:4150 --env-file /etc/opsee/bastion-env.sh quay.io/opsee/bastion:${BASTION_VERSION} /checker
+ExecStart=/usr/bin/docker run --name %p --net=container:connector --device=/dev/net/tun -e ETCD_HOST=http://etcd:2379 -e NSQD_HOST=nsqd:4150 --env-file /etc/opsee/bastion-env.sh quay.io/opsee/bastion:${BASTION_VERSION} /checker -admin_port=4000
 ExecStop=/usr/bin/docker stop -t 5 %p
 
 [Install]


### PR DESCRIPTION
Everything was made to look exactly like monitor.service looked before I started touching anything.
