### PR TITLE
Prevent Monitor from attempting to monitor services that aren't in it's map of monitored services (avoid null pointer deref)

### DIFF
--- a/src/cmd/monitor/main.go
+++ b/src/cmd/monitor/main.go
@@ -22,6 +22,7 @@ var (
 func main() {
 	cfg := config.GetConfig()
 	listenAddress := fmt.Sprintf(":%d", cfg.AdminPort)
+
 	mon, err := monitor.NewMonitor()
 	if err != nil {
 		logger.Fatal(err.Error())


### PR DESCRIPTION
The bastion's Monitor service maintains monitors a fixed number of bastion services (e.g. "checker", "discovery"). These services are stored in a var []string and used at service startup to build a map of Components (other services that produce HeartBeats) to monitor. The list is not updated dynamically (to my knowledge). Monitor subscribes to the "heartbeat" NSQ topic and attempts to unmarshall and check all HeartBeat events.

No check existed to confirm that the consumed event's service type had a corresponding component in the map. In the case when the component did not exist in the map, a nil pointer dereference occurred. 
