### PR TITLE
Remove Unit from TimeoutStopSec.  Takes a unit-less value in seconds

### DIFF
--- a/build/hacker.service
+++ b/build/hacker.service
@@ -6,13 +6,13 @@ Requires=env-lock.service docker.service connector.service
 [Service]
 User=core
 Restart=on-failure
-TimeoutStopSec=210s # wait 30 more seconds for the docker container to execstop prior to sigkill
+TimeoutStopSec=210 
 EnvironmentFile=/etc/opsee/bastion-env.sh
 ExecStartPre=-/usr/bin/docker stop -t 5 %p
 ExecStartPre=-/usr/bin/docker rm %p
 ExecStartPre=/usr/bin/docker pull quay.io/opsee/bastion:${BASTION_VERSION}
 ExecStart=/usr/bin/docker run --name %p quay.io/opsee/bastion:${BASTION_VERSION} /hacker
-ExecStop=/usr/bin/docker stop -t 180 %p #wait 180 seconds before sending a sigterm
+ExecStop=/usr/bin/docker stop -t 180 %p 
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
```
TimeoutStopSec=5m is valid.
TimeoutStopSec=210s #comment is not valid.
TimeoutStopSec=3min 30s is valid.
TimeoutStopSec=210 is valid?
```

Time span values encoded in unit files can be written in various formats. A stand-alone number specifies a time in seconds. If suffixed with a time unit, the unit is honored. A concatenation of multiple values with units is supported, in which case the values are added up. Example: "50" refers to 50 seconds; "2min 200ms" refers to 2 minutes plus 200 milliseconds, i.e. 120200ms. The following time units are understood: s, min, h, d, w, ms, us. For details see systemd.time(7).

Also EOL comments cause units to fail. 
