### PR TITLE
Test check runner

### DIFF
--- a/build/checker.service
+++ b/build/checker.service
@@ -14,7 +14,7 @@ EnvironmentFile=/etc/opsee/bastion-env.sh
 ExecStartPre=-/usr/bin/docker stop -t 5 %p
 ExecStartPre=-/usr/bin/docker rm %p
 ExecStartPre=/usr/bin/docker pull quay.io/opsee/bastion:${BASTION_VERSION}
-ExecStart=/usr/bin/docker run --name %p --net=container:connector --device=/dev/net/tun -e ETCD_HOST=http://etcd:2379 -e NSQD_HOST=nsqd:4150 --env-file /etc/opsee/bastion-env.sh quay.io/opsee/bastion:${BASTION_VERSION} /checker -admin_port=4000
+ExecStart=/usr/bin/docker run --name %p --net=container:connector --device=/dev/net/tun -e ETCD_HOST=http://etcd:2379 -e NSQD_HOST=nsqd:4150 --env-file /etc/opsee/bastion-env.sh quay.io/opsee/bastion:${BASTION_VERSION} /checker -admin_port=4000 --results test_check_results --requests test_check --channel checker_test_check_results
 ExecStop=/usr/bin/docker stop -t 5 %p
 
 [Install]

--- a/build/mami.json
+++ b/build/mami.json
@@ -67,6 +67,10 @@
             "type":"systemd",
             "unit-file":"build/runner.service"
         },
+        {
+            "type":"systemd",
+            "unit-file":"build/test-runner.service"
+        },
          {
             "type":"systemd",
             "unit-file":"build/shovel-discovery.service"

--- a/build/test-runner.service
+++ b/build/test-runner.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Bastion - TestCheck Runner
+After=env-lock.service docker.service nsqd.service
+Requires=env-lock.service docker.service nsqd.service
+
+[Service]
+Restart=always
+User=core
+TimeoutStartSec=0
+EnvironmentFile=/etc/opsee/bastion-env.sh
+ExecStartPre=-/usr/bin/docker stop -t 5 %p
+ExecStartPre=-/usr/bin/docker rm %p
+ExecStartPre=/usr/bin/docker pull quay.io/opsee/bastion:${BASTION_VERSION}
+ExecStart=/usr/bin/docker run --name %p --link nsqd:nsqd -e CUSTOMER_ID -e NSQD_HOST=nsqd:4150 --env-file /etc/opsee/bastion-env.sh quay.io/opsee/bastion:${BASTION_VERSION} /runner --channel test_runner --requests test_check --results test_check_results 
+ExecStop=/usr/bin/docker stop -t 5 %p
+
+[Install]
+WantedBy=multi-user.target

--- a/circle.yml
+++ b/circle.yml
@@ -20,12 +20,14 @@ dependencies:
     - go version
     - docker login -e $DOCKER_EMAIL -u $DOCKER_USERNAME -p $DOCKER_PASSWORD quay.io
     - docker pull quay.io/opsee/build-go:latest
+    - docker pull nsqio/nsq:v0.3.5
+    - docker run --name nsqd -d --expose 4150 --expose 4151 nsqio/nsq:v0.3.5 /nsqd
     - sudo pip install awscli
     - if [[ ! -e mami/mami.jar ]]; then mkdir mami && aws s3 cp s3://opsee-releases/clj/mami/master/mami-0.1.0-SNAPSHOT-standalone.jar mami/mami.jar; fi
     - git submodule update --init
 test:
   override:
-    - docker run -e "TARGETS=linux/amd64" -v `pwd`:/build quay.io/opsee/build-go
+    - docker run -e "TARGETS=linux/amd64" --link nsqd -e "NSQD_HOST=nsqd:4150" -v `pwd`:/build quay.io/opsee/build-go
     - docker build -t quay.io/opsee/bastion:$CIRCLE_SHA1 .
     - docker push quay.io/opsee/bastion:$CIRCLE_SHA1
     - java -jar mami/mami.jar build --bastion-version $CIRCLE_SHA1 build/mami.json

--- a/src/github.com/opsee/bastion/checker/checker.go
+++ b/src/github.com/opsee/bastion/checker/checker.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/golang/protobuf/proto"
+	"github.com/nsqio/go-nsq"
+	"github.com/nu7hatch/gouuid"
 	"github.com/opsee/bastion/logging"
-	"github.com/opsee/bastion/messaging"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
@@ -97,6 +99,126 @@ func MarshalAny(i interface{}) (*Any, error) {
 
 type Interval time.Duration
 
+type RemoteRunner struct {
+	consumer   *nsq.Consumer
+	producer   *nsq.Producer
+	config     *NSQRunnerConfig
+	requestMap map[string]chan *CheckResult // TODO(greg): I really want NBHM for Golang. :(
+	sync.RWMutex
+}
+
+func NewRemoteRunner(cfg *NSQRunnerConfig) (*RemoteRunner, error) {
+	consumer, err := nsq.NewConsumer(cfg.ConsumerQueueName, cfg.ConsumerChannelName, nsq.NewConfig())
+	if err != nil {
+		return nil, err
+	}
+	producer, err := nsq.NewProducer(cfg.NSQDHost, nsq.NewConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	r := &RemoteRunner{
+		requestMap: make(map[string]chan *CheckResult),
+		consumer:   consumer,
+		producer:   producer,
+		config:     cfg,
+	}
+	consumer.AddConcurrentHandlers(nsq.HandlerFunc(func(m *nsq.Message) error {
+		chk := &CheckResult{}
+		err := proto.Unmarshal(m.Body, chk)
+		if err != nil {
+			logger.Error(err.Error())
+			return err
+		}
+
+		logger.Debug("RemoteRunner handling check: %s", chk.String())
+
+		var respChan chan *CheckResult
+
+		r.withLock(func() {
+			respChan = r.requestMap[chk.CheckId]
+			logger.Debug("RemoteRunner handler: Got response channel: %s", respChan)
+		})
+
+		if respChan == nil {
+			logger.Info("Received unexpected result: %s", chk.String())
+			return nil
+		}
+
+		// There is a 1:1 mapping of TestCheck calls to CheckResults, so we close
+		// the channel here after writing, making it safe to delete the channel
+		// once we've returned from RunCheck. We will incur a GC penalty for doing
+		// this if the result is never read, but I think we can manage. It might be
+		// nice to really understand what the cost of this approach is, but I don't
+		// think it's particularly important. -greg
+		respChan <- chk
+		logger.Debug("RemoteRunner handler sent result to channel.")
+		close(respChan)
+		return nil
+	}), cfg.MaxHandlers)
+
+	err = consumer.ConnectToNSQD(cfg.NSQDHost)
+	if err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func (r *RemoteRunner) withLock(f func()) {
+	logger.Debug("Acquiring lock on RemoteRunner.")
+	r.Lock()
+	f()
+	r.Unlock()
+	logger.Debug("Releasing lock on RemoteRunner.")
+}
+
+func (r *RemoteRunner) RunCheck(ctx context.Context, chk *Check) (*CheckResult, error) {
+	logger.Info("Running check: %s", chk.String())
+	id, err := uuid.NewV4()
+	if err != nil {
+		return nil, err
+	}
+	chk.Id = id.String()
+
+	respChan := make(chan *CheckResult, 1)
+
+	r.withLock(func() {
+		r.requestMap[id.String()] = respChan
+		logger.Debug("RemoteRunner.RunCheck: Set response channel for request: %s", id.String())
+	})
+
+	defer func() {
+		r.withLock(func() {
+			delete(r.requestMap, id.String())
+			logger.Debug("Deleted response channel.")
+		})
+	}()
+
+	msg, err := proto.Marshal(chk)
+	if err != nil {
+		logger.Error(err.Error())
+		return nil, err
+	}
+	logger.Debug("RemoteRunner.RunCheck: publishing request to run check: %s", chk.String())
+	r.producer.Publish(r.config.ProducerQueueName, msg)
+
+	select {
+	case result := <-respChan:
+		logger.Debug("RemoteRunner.RunCheck: Got result from resopnse channel: %s", result.String())
+		return result, nil
+	case <-ctx.Done():
+		logger.Error(ctx.Err().Error())
+		return nil, ctx.Err()
+	}
+}
+
+func (r *RemoteRunner) Stop() {
+	r.consumer.Stop()
+	<-r.consumer.StopChan
+	r.producer.Stop()
+}
+
 // Checker must:
 //    - Add a check
 //    - Delete a check
@@ -105,11 +227,9 @@ type Interval time.Duration
 
 type Checker struct {
 	Port       int
-	Consumer   messaging.Consumer
-	Producer   messaging.Producer
 	Scheduler  *Scheduler
-	Runner     *Runner
 	grpcServer *grpc.Server
+	Runner     *RemoteRunner
 }
 
 func NewChecker() *Checker {
@@ -179,24 +299,30 @@ func (c *Checker) TestCheck(ctx context.Context, req *TestCheckRequest) (*TestCh
 		return nil, fmt.Errorf("Deadline required but missing in request. %v", req)
 	}
 	deadline := time.Unix(req.Deadline.Seconds, req.Deadline.Nanos)
+	logger.Debug("TestCheck deadline is %d from now.", deadline.Sub(time.Now()).String())
 	// We add the request deadline here, and the Runner will adhere to that
 	// deadline.
 	ctx, _ = context.WithDeadline(ctx, deadline)
-	ctx = context.WithValue(ctx, "MaxHosts", int(req.MaxHosts))
 
 	testCheckResponse := &TestCheckResponse{}
 
-	responses, err := c.Runner.RunCheck(ctx, req.Check)
+	result, err := c.Runner.RunCheck(ctx, req.Check)
 	if err != nil {
 		testCheckResponse.Error = handleError(err)
 		return testCheckResponse, nil
 	}
 
-	var responseArr []*CheckResponse
-	for response := range responses {
-		responseArr = append(responseArr, response)
+	responses := result.GetResponses()
+
+	maxHosts := int(req.MaxHosts)
+	if maxHosts == 0 {
+		maxHosts = len(responses)
 	}
-	testCheckResponse.Responses = responseArr
+	if maxHosts > len(responses) {
+		maxHosts = len(responses)
+	}
+
+	testCheckResponse.Responses = responses[:maxHosts]
 
 	logger.Info("Response: %v", testCheckResponse)
 	return testCheckResponse, nil
@@ -218,16 +344,7 @@ func (c *Checker) Start() error {
 }
 
 func (c *Checker) Stop() {
-	if c.Consumer != nil {
-		if err := c.Consumer.Close(); err != nil {
-			logger.Error(err.Error())
-		}
-	}
-	if c.Producer != nil {
-		if err := c.Producer.Close(); err != nil {
-			logger.Error(err.Error())
-		}
-	}
+	c.Runner.Stop()
 	c.grpcServer.Stop()
 	c.Scheduler.Stop()
 }

--- a/src/github.com/opsee/bastion/checker/checker_test.go
+++ b/src/github.com/opsee/bastion/checker/checker_test.go
@@ -5,6 +5,11 @@ package checker
 // worth testing.
 
 import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -35,15 +40,44 @@ type CheckerTestSuite struct {
 	Context          context.Context
 	TestCheckRequest *TestCheckRequest
 	Publisher        Publisher
+	NSQRunner        *NSQRunner
+	RunnerConfig     *NSQRunnerConfig
+}
+
+func (s *CheckerTestSuite) SetupSuite() {
+	cfg := &NSQRunnerConfig{
+		NSQDHost:            os.Getenv("NSQD_HOST"),
+		ConsumerQueueName:   "test-runner",
+		ProducerQueueName:   "test-results",
+		ConsumerChannelName: "test-runner",
+		MaxHandlers:         1,
+		CustomerID:          "test",
+	}
+	runner, err := NewNSQRunner(NewRunner(newTestResolver()), cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	s.NSQRunner = runner
+	s.RunnerConfig = cfg
 }
 
 func (s *CheckerTestSuite) SetupTest() {
 	var err error
 
-	// Reset the channel for every test, so we don't accidentally read stale
-	// barbage from a previous test
 	checker := NewChecker()
-	testRunner := NewRunner(newTestResolver())
+	testRunner, err := NewRemoteRunner(&NSQRunnerConfig{
+		NSQDHost:            s.RunnerConfig.NSQDHost,
+		ConsumerQueueName:   s.RunnerConfig.ProducerQueueName,
+		ConsumerChannelName: "test-check-results",
+		ProducerQueueName:   s.RunnerConfig.ConsumerQueueName,
+		MaxHandlers:         1,
+		CustomerID:          s.RunnerConfig.CustomerID,
+	})
+	if err != nil {
+		panic(err)
+	}
+
 	checker.Scheduler = NewScheduler()
 	checker.Scheduler.Producer = &testPublisher{make(chan []byte, 1)}
 	checker.Runner = testRunner
@@ -53,16 +87,17 @@ func (s *CheckerTestSuite) SetupTest() {
 	s.Checker = checker
 
 	checkerClient, err := NewRpcClient("127.0.0.1", 4000)
-	assert.Nil(s.T(), err)
+	if err != nil {
+		panic(err)
+	}
+
 	s.CheckerClient = checkerClient
 	s.Context = context.Background()
 	s.Common = TestCommonStubs{}
 	s.TestCheckRequest = &TestCheckRequest{
 		MaxHosts: 1,
-		Deadline: &Timestamp{
-			Nanos: time.Now().Add(30 * time.Minute).UnixNano(),
-		},
-		Check: nil,
+		Deadline: nil,
+		Check:    nil,
 	}
 
 	s.Publisher = &testPublisher{}
@@ -71,6 +106,27 @@ func (s *CheckerTestSuite) SetupTest() {
 func (s *CheckerTestSuite) TearDownTest() {
 	s.CheckerClient.Close()
 	s.Checker.Stop()
+	// Reset NSQ state every time so that we don't end up reading stale garbage.
+	ip := strings.Split(s.RunnerConfig.NSQDHost, ":")[0]
+	resp, err := http.PostForm(fmt.Sprintf("http://%s:4151/topic/empty", ip), url.Values{"topic": {s.RunnerConfig.ConsumerQueueName}})
+	logger.Debug("Received response from NSQD: %s", resp)
+	if err != nil {
+		panic(err)
+	}
+	_, err = http.PostForm(fmt.Sprintf("http://%s:4151/topic/empty", ip), url.Values{"topic": {s.RunnerConfig.ConsumerQueueName}})
+	if err != nil {
+		panic(err)
+	}
+	_, err = http.PostForm(fmt.Sprintf("http://%s:4151/channel/empty", ip), url.Values{"topic": {s.RunnerConfig.ConsumerQueueName},
+		"channel": {s.RunnerConfig.ConsumerChannelName}})
+	if err != nil {
+		panic(err)
+	}
+	_, err = http.PostForm(fmt.Sprintf("http://%s:4151/channel/empty", ip), url.Values{"topic": {s.RunnerConfig.ProducerQueueName},
+		"channel": {"test-check-results"}})
+	if err != nil {
+		panic(err)
+	}
 }
 
 /*******************************************************************************
@@ -94,6 +150,9 @@ func (s *CheckerTestSuite) buildTestCheckRequest(check *HttpCheck, target *Targe
 	c.Target = target
 
 	request.Check = c
+	request.Deadline = &Timestamp{
+		Nanos: time.Now().Add(3 * time.Second).UnixNano(),
+	}
 	return request, nil
 }
 
@@ -172,6 +231,7 @@ func (s *CheckerTestSuite) TestCheckAdheresToMaxHosts() {
 	target := &Target{
 		Type: "sg",
 		Id:   "sg3",
+		Name: "sg3",
 	}
 	request, err := s.buildTestCheckRequest(s.Common.HTTPCheck(), target)
 	request.MaxHosts = 1
@@ -189,5 +249,6 @@ func (s *CheckerTestSuite) TestUpdateCheck() {
 }
 
 func TestCheckerTestSuite(t *testing.T) {
+	setupTestEnv()
 	suite.Run(t, new(CheckerTestSuite))
 }

--- a/src/github.com/opsee/bastion/checker/common_test.go
+++ b/src/github.com/opsee/bastion/checker/common_test.go
@@ -37,7 +37,7 @@ func (t TestCommonStubs) HTTPRequest() *HTTPRequest {
 
 func (t TestCommonStubs) Check() *Check {
 	return &Check{
-		Id:        "string",
+		Id:        "stub-check-id",
 		Interval:  60,
 		Target:    &Target{},
 		CheckSpec: &Any{},
@@ -137,7 +137,13 @@ func newTestResolver() *testResolver {
 	}
 }
 
-func init() {
+var testEnvReady bool = false
+
+func setupTestEnv() {
+	if testEnvReady {
+		return
+	}
+
 	logLevel := os.Getenv("LOG_LEVEL")
 	if logLevel == "" {
 		logLevel = "ERROR"
@@ -155,4 +161,6 @@ func init() {
 	go func() {
 		errChan <- http.ListenAndServe(fmt.Sprintf(":%d", testHTTPServerPort), nil)
 	}()
+
+	testEnvReady = true
 }

--- a/src/github.com/opsee/bastion/checker/dispatcher_test.go
+++ b/src/github.com/opsee/bastion/checker/dispatcher_test.go
@@ -116,5 +116,6 @@ func (s *DispatcherTestSuite) TestDispatchWithCancelledContext() {
 }
 
 func TestDispatcherTestSuite(t *testing.T) {
+	setupTestEnv()
 	suite.Run(t, new(DispatcherTestSuite))
 }

--- a/src/github.com/opsee/bastion/checker/scheduler_test.go
+++ b/src/github.com/opsee/bastion/checker/scheduler_test.go
@@ -126,5 +126,6 @@ func BenchmarkRunCheckParallel(b *testing.B) {
 }
 
 func TestSchedulerTestSuite(t *testing.T) {
+	setupTestEnv()
 	suite.Run(t, new(SchedulerTestSuite))
 }

--- a/vendor/src/github.com/nu7hatch/gouuid/COPYING
+++ b/vendor/src/github.com/nu7hatch/gouuid/COPYING
@@ -1,0 +1,19 @@
+Copyright (C) 2011 by Krzysztof Kowalik <chris@nu7hat.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/src/github.com/nu7hatch/gouuid/README.md
+++ b/vendor/src/github.com/nu7hatch/gouuid/README.md
@@ -1,0 +1,21 @@
+# Pure Go UUID implementation
+
+This package provides immutable UUID structs and the functions
+NewV3, NewV4, NewV5 and Parse() for generating versions 3, 4
+and 5 UUIDs as specified in [RFC 4122](http://www.ietf.org/rfc/rfc4122.txt).
+
+## Installation
+
+Use the `go` tool:
+
+	$ go get github.com/nu7hatch/gouuid
+
+## Usage
+
+See [documentation and examples](http://godoc.org/github.com/nu7hatch/gouuid)
+for more information.
+
+## Copyright
+
+Copyright (C) 2011 by Krzysztof Kowalik <chris@nu7hat.ch>. See [COPYING](https://github.com/nu7hatch/gouuid/tree/master/COPYING)
+file for details.

--- a/vendor/src/github.com/nu7hatch/gouuid/example_test.go
+++ b/vendor/src/github.com/nu7hatch/gouuid/example_test.go
@@ -1,0 +1,33 @@
+package uuid_test
+
+import (
+	"fmt"
+	"github.com/nu7hatch/gouuid"
+)
+
+func ExampleNewV4() {
+	u4, err := uuid.NewV4()
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(u4)
+}
+
+func ExampleNewV5() {
+	u5, err := uuid.NewV5(uuid.NamespaceURL, []byte("nu7hat.ch"))
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(u5)
+}
+
+func ExampleParseHex() {
+	u, err := uuid.ParseHex("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(u)
+}

--- a/vendor/src/github.com/nu7hatch/gouuid/uuid.go
+++ b/vendor/src/github.com/nu7hatch/gouuid/uuid.go
@@ -1,0 +1,173 @@
+// This package provides immutable UUID structs and the functions
+// NewV3, NewV4, NewV5 and Parse() for generating versions 3, 4
+// and 5 UUIDs as specified in RFC 4122.
+//
+// Copyright (C) 2011 by Krzysztof Kowalik <chris@nu7hat.ch>
+package uuid
+
+import (
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"regexp"
+)
+
+// The UUID reserved variants. 
+const (
+	ReservedNCS       byte = 0x80
+	ReservedRFC4122   byte = 0x40
+	ReservedMicrosoft byte = 0x20
+	ReservedFuture    byte = 0x00
+)
+
+// The following standard UUIDs are for use with NewV3() or NewV5().
+var (
+	NamespaceDNS, _  = ParseHex("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	NamespaceURL, _  = ParseHex("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
+	NamespaceOID, _  = ParseHex("6ba7b812-9dad-11d1-80b4-00c04fd430c8")
+	NamespaceX500, _ = ParseHex("6ba7b814-9dad-11d1-80b4-00c04fd430c8")
+)
+
+// Pattern used to parse hex string representation of the UUID.
+// FIXME: do something to consider both brackets at one time,
+// current one allows to parse string with only one opening
+// or closing bracket.
+const hexPattern = "^(urn\\:uuid\\:)?\\{?([a-z0-9]{8})-([a-z0-9]{4})-" +
+	"([1-5][a-z0-9]{3})-([a-z0-9]{4})-([a-z0-9]{12})\\}?$"
+
+var re = regexp.MustCompile(hexPattern)
+
+// A UUID representation compliant with specification in
+// RFC 4122 document.
+type UUID [16]byte
+
+// ParseHex creates a UUID object from given hex string
+// representation. Function accepts UUID string in following
+// formats:
+//
+//     uuid.ParseHex("6ba7b814-9dad-11d1-80b4-00c04fd430c8")
+//     uuid.ParseHex("{6ba7b814-9dad-11d1-80b4-00c04fd430c8}")
+//     uuid.ParseHex("urn:uuid:6ba7b814-9dad-11d1-80b4-00c04fd430c8")
+//
+func ParseHex(s string) (u *UUID, err error) {
+	md := re.FindStringSubmatch(s)
+	if md == nil {
+		err = errors.New("Invalid UUID string")
+		return
+	}
+	hash := md[2] + md[3] + md[4] + md[5] + md[6]
+	b, err := hex.DecodeString(hash)
+	if err != nil {
+		return
+	}
+	u = new(UUID)
+	copy(u[:], b)
+	return
+}
+
+// Parse creates a UUID object from given bytes slice.
+func Parse(b []byte) (u *UUID, err error) {
+	if len(b) != 16 {
+		err = errors.New("Given slice is not valid UUID sequence")
+		return
+	}
+	u = new(UUID)
+	copy(u[:], b)
+	return
+}
+
+// Generate a UUID based on the MD5 hash of a namespace identifier
+// and a name.
+func NewV3(ns *UUID, name []byte) (u *UUID, err error) {
+	if ns == nil {
+		err = errors.New("Invalid namespace UUID")
+		return
+	}
+	u = new(UUID)
+	// Set all bits to MD5 hash generated from namespace and name.
+	u.setBytesFromHash(md5.New(), ns[:], name)
+	u.setVariant(ReservedRFC4122)
+	u.setVersion(3)
+	return
+}
+
+// Generate a random UUID.
+func NewV4() (u *UUID, err error) {
+	u = new(UUID)
+	// Set all bits to randomly (or pseudo-randomly) chosen values.
+	_, err = rand.Read(u[:])
+	if err != nil {
+		return
+	}
+	u.setVariant(ReservedRFC4122)
+	u.setVersion(4)
+	return
+}
+
+// Generate a UUID based on the SHA-1 hash of a namespace identifier
+// and a name.
+func NewV5(ns *UUID, name []byte) (u *UUID, err error) {
+	u = new(UUID)
+	// Set all bits to truncated SHA1 hash generated from namespace
+	// and name.
+	u.setBytesFromHash(sha1.New(), ns[:], name)
+	u.setVariant(ReservedRFC4122)
+	u.setVersion(5)
+	return
+}
+
+// Generate a MD5 hash of a namespace and a name, and copy it to the
+// UUID slice.
+func (u *UUID) setBytesFromHash(hash hash.Hash, ns, name []byte) {
+	hash.Write(ns[:])
+	hash.Write(name)
+	copy(u[:], hash.Sum([]byte{})[:16])
+}
+
+// Set the two most significant bits (bits 6 and 7) of the
+// clock_seq_hi_and_reserved to zero and one, respectively.
+func (u *UUID) setVariant(v byte) {
+	switch v {
+	case ReservedNCS:
+		u[8] = (u[8] | ReservedNCS) & 0xBF
+	case ReservedRFC4122:
+		u[8] = (u[8] | ReservedRFC4122) & 0x7F
+	case ReservedMicrosoft:
+		u[8] = (u[8] | ReservedMicrosoft) & 0x3F
+	}
+}
+
+// Variant returns the UUID Variant, which determines the internal
+// layout of the UUID. This will be one of the constants: RESERVED_NCS,
+// RFC_4122, RESERVED_MICROSOFT, RESERVED_FUTURE.
+func (u *UUID) Variant() byte {
+	if u[8]&ReservedNCS == ReservedNCS {
+		return ReservedNCS
+	} else if u[8]&ReservedRFC4122 == ReservedRFC4122 {
+		return ReservedRFC4122
+	} else if u[8]&ReservedMicrosoft == ReservedMicrosoft {
+		return ReservedMicrosoft
+	}
+	return ReservedFuture
+}
+
+// Set the four most significant bits (bits 12 through 15) of the
+// time_hi_and_version field to the 4-bit version number.
+func (u *UUID) setVersion(v byte) {
+	u[6] = (u[6] & 0xF) | (v << 4)
+}
+
+// Version returns a version number of the algorithm used to
+// generate the UUID sequence.
+func (u *UUID) Version() uint {
+	return uint(u[6] >> 4)
+}
+
+// Returns unparsed version of the generated UUID sequence.
+func (u *UUID) String() string {
+	return fmt.Sprintf("%x-%x-%x-%x-%x", u[0:4], u[4:6], u[6:8], u[8:10], u[10:])
+}

--- a/vendor/src/github.com/nu7hatch/gouuid/uuid_test.go
+++ b/vendor/src/github.com/nu7hatch/gouuid/uuid_test.go
@@ -1,0 +1,135 @@
+// This package provides immutable UUID structs and the functions
+// NewV3, NewV4, NewV5 and Parse() for generating versions 3, 4
+// and 5 UUIDs as specified in RFC 4122.
+//
+// Copyright (C) 2011 by Krzysztof Kowalik <chris@nu7hat.ch>
+package uuid
+
+import (
+	"regexp"
+	"testing"
+)
+
+const format = "^[a-z0-9]{8}-[a-z0-9]{4}-[1-5][a-z0-9]{3}-[a-z0-9]{4}-[a-z0-9]{12}$"
+
+func TestParse(t *testing.T) {
+	_, err := Parse([]byte{1, 2, 3, 4, 5})
+	if err == nil {
+		t.Errorf("Expected error due to invalid UUID sequence")
+	}
+	base, _ := NewV4()
+	u, err := Parse(base[:])
+	if err != nil {
+		t.Errorf("Expected to parse UUID sequence without problems")
+		return
+	}
+	if u.String() != base.String() {
+		t.Errorf("Expected parsed UUID to be the same as base, %s != %s", u.String(), base.String())
+	}
+}
+
+func TestParseString(t *testing.T) {
+	_, err := ParseHex("foo")
+	if err == nil {
+		t.Errorf("Expected error due to invalid UUID string")
+	}
+	base, _ := NewV4()
+	u, err := ParseHex(base.String())
+	if err != nil {
+		t.Errorf("Expected to parse UUID sequence without problems")
+		return
+	}
+	if u.String() != base.String() {
+		t.Errorf("Expected parsed UUID to be the same as base, %s != %s", u.String(), base.String())
+	}
+}
+
+func TestNewV3(t *testing.T) {
+	u, err := NewV3(NamespaceURL, []byte("golang.org"))
+	if err != nil {
+		t.Errorf("Expected to generate UUID without problems, error thrown: %d", err.Error())
+		return
+	}
+	if u.Version() != 3 {
+		t.Errorf("Expected to generate UUIDv3, given %d", u.Version())
+	}
+	if u.Variant() != ReservedRFC4122 {
+		t.Errorf("Expected to generate UUIDv3 RFC4122 variant, given %x", u.Variant())
+	}
+	re := regexp.MustCompile(format)
+	if !re.MatchString(u.String()) {
+		t.Errorf("Expected string representation to be valid, given %s", u.String())
+	}
+	u2, _ := NewV3(NamespaceURL, []byte("golang.org"))
+	if u2.String() != u.String() {
+		t.Errorf("Expected UUIDs generated of the same namespace and name to be the same")
+	}
+	u3, _ := NewV3(NamespaceDNS, []byte("golang.org"))
+	if u3.String() == u.String() {
+		t.Errorf("Expected UUIDs generated of different namespace and the same name to be different")
+	}
+	u4, _ := NewV3(NamespaceURL, []byte("code.google.com"))
+	if u4.String() == u.String() {
+		t.Errorf("Expected UUIDs generated of the same namespace and different names to be different")
+	}
+}
+
+func TestNewV4(t *testing.T) {
+	u, err := NewV4()
+	if err != nil {
+		t.Errorf("Expected to generate UUID without problems, error thrown: %s", err.Error())
+		return
+	}
+	if u.Version() != 4 {
+		t.Errorf("Expected to generate UUIDv4, given %d", u.Version())
+	}
+	if u.Variant() != ReservedRFC4122 {
+		t.Errorf("Expected to generate UUIDv4 RFC4122 variant, given %x", u.Variant())
+	}
+	re := regexp.MustCompile(format)
+	if !re.MatchString(u.String()) {
+		t.Errorf("Expected string representation to be valid, given %s", u.String())
+	}
+}
+
+func TestNewV5(t *testing.T) {
+	u, err := NewV5(NamespaceURL, []byte("golang.org"))
+	if err != nil {
+		t.Errorf("Expected to generate UUID without problems, error thrown: %d", err.Error())
+		return
+	}
+	if u.Version() != 5 {
+		t.Errorf("Expected to generate UUIDv5, given %d", u.Version())
+	}
+	if u.Variant() != ReservedRFC4122 {
+		t.Errorf("Expected to generate UUIDv5 RFC4122 variant, given %x", u.Variant())
+	}
+	re := regexp.MustCompile(format)
+	if !re.MatchString(u.String()) {
+		t.Errorf("Expected string representation to be valid, given %s", u.String())
+	}
+	u2, _ := NewV5(NamespaceURL, []byte("golang.org"))
+	if u2.String() != u.String() {
+		t.Errorf("Expected UUIDs generated of the same namespace and name to be the same")
+	}
+	u3, _ := NewV5(NamespaceDNS, []byte("golang.org"))
+	if u3.String() == u.String() {
+		t.Errorf("Expected UUIDs generated of different namespace and the same name to be different")
+	}
+	u4, _ := NewV5(NamespaceURL, []byte("code.google.com"))
+	if u4.String() == u.String() {
+		t.Errorf("Expected UUIDs generated of the same namespace and different names to be different")
+	}
+}
+
+func BenchmarkParseHex(b *testing.B) {
+	s := "f3593cff-ee92-40df-4086-87825b523f13"
+	for i := 0; i < b.N; i++ {
+		_, err := ParseHex(s)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	b.ReportAllocs()
+}


### PR DESCRIPTION
The runner that executes checks for TestCheck has to be on the customer side, not the opsee side network. This adds configuration parameters to both the checker and runner and adds a new runner to the bastion specifically for handling TestCheck requests.
