### PR TITLE
Add TimeoutStartSec=0 to prevent long docker pulls from killing Units…

### DIFF
--- a/build/bastion-etcd.service
+++ b/build/bastion-etcd.service
@@ -7,6 +7,7 @@ Requires=env-lock.service docker.service
 Restart=always
 User=core
 TimeoutStartSec=0
+RestartSec=5s
 ExecStartPre=-/usr/bin/docker stop -t 5 %p
 ExecStartPre=-/usr/bin/docker rm %p
 ExecStartPre=/usr/bin/docker pull quay.io/coreos/etcd:v2.0.8

--- a/build/discovery.service
+++ b/build/discovery.service
@@ -6,8 +6,8 @@ Requires=env-lock.service docker.service nsqd.service hacker.service
 [Service]
 Restart=always
 User=core
-TimeoutStartSec=5s
 RestartSec=5s
+TimeoutStartSec=0
 EnvironmentFile=/etc/opsee/bastion-env.sh
 ExecStartPre=-/usr/bin/docker stop -t 5 %p
 ExecStartPre=-/usr/bin/docker rm %p

--- a/build/env-lock.service
+++ b/build/env-lock.service
@@ -1,8 +1,11 @@
 [Unit]
 Description=Triggered after generation of env file
+ConditionFileNotEmpty=/etc/opsee/bastion-env.sh
+ConditionPathIsReadWrite=/etc/opsee/bastion-env.sh
 
 [Service]
-Type=oneshot
+Restart=always
+RestartSec=1s
 ExecStart=/bin/sh -c "echo Bastion Env Ready"
 RemainAfterExit=yes
 

--- a/build/hacker.service
+++ b/build/hacker.service
@@ -6,7 +6,9 @@ Requires=env-lock.service docker.service connector.service
 [Service]
 User=core
 Restart=on-failure
+TimeoutStartSec=0
 TimeoutStopSec=210 
+RestartSec=5s
 EnvironmentFile=/etc/opsee/bastion-env.sh
 ExecStartPre=-/usr/bin/docker stop -t 5 %p
 ExecStartPre=-/usr/bin/docker rm %p

--- a/build/monitor.service
+++ b/build/monitor.service
@@ -6,7 +6,7 @@ Requires=env-lock.service docker.service nsqd.service connector.service
 [Service]
 Restart=always
 User=core
-TimeoutStartSec=5s
+TimeoutStartSec=0
 RestartSec=5s
 Environment="NSQD_HOST=127.0.0.1:4150"
 EnvironmentFile=/etc/opsee/bastion-env.sh

--- a/build/nsqadmin.service
+++ b/build/nsqadmin.service
@@ -7,6 +7,7 @@ Requires=env-lock.service docker.service nsqd.service
 Restart=always
 User=core
 TimeoutStartSec=0
+RestartSec=5s
 ExecStartPre=-/usr/bin/docker stop -t 5 %p
 ExecStartPre=-/usr/bin/docker rm %p
 ExecStartPre=/usr/bin/docker pull nsqio/nsq:v0.3.5

--- a/build/nsqd.service
+++ b/build/nsqd.service
@@ -7,6 +7,7 @@ Requires=env-lock.service docker.service
 Restart=always
 User=core
 TimeoutStartSec=0
+RestartSec=5s
 ExecStartPre=-/usr/bin/docker stop -t 5 %p
 ExecStartPre=-/usr/bin/docker rm %p
 ExecStartPre=/usr/bin/docker pull nsqio/nsq:v0.3.5

--- a/build/register.service
+++ b/build/register.service
@@ -9,7 +9,6 @@ Restart=always
 EnvironmentFile=/etc/opsee/bastion-env.sh
 User=core
 TimeoutStartSec=0
-StartLimitInterval=0
 RestartSec=5s
 ExecStartPre=-/usr/bin/docker stop -t 5 %p
 ExecStartPre=-/usr/bin/docker rm %p

--- a/build/runner.service
+++ b/build/runner.service
@@ -7,6 +7,7 @@ Requires=env-lock.service docker.service nsqd.service
 Restart=always
 User=core
 TimeoutStartSec=0
+RestartSec=5s
 EnvironmentFile=/etc/opsee/bastion-env.sh
 ExecStartPre=-/usr/bin/docker stop -t 5 %p
 ExecStartPre=-/usr/bin/docker rm %p

--- a/build/shovel-discovery.service
+++ b/build/shovel-discovery.service
@@ -9,6 +9,7 @@ Restart=always
 EnvironmentFile=/etc/opsee/bastion-env.sh
 User=core
 TimeoutStartSec=0
+RestartSec=5s
 ExecStartPre=-/usr/bin/docker stop -t 5 %p
 ExecStartPre=-/usr/bin/docker rm %p
 ExecStartPre=/usr/bin/docker pull nsqio/nsq:v0.3.5

--- a/build/shovel-results.service
+++ b/build/shovel-results.service
@@ -9,6 +9,7 @@ Restart=always
 EnvironmentFile=/etc/opsee/bastion-env.sh
 User=core
 TimeoutStartSec=0
+RestartSec=5s
 ExecStartPre=-/usr/bin/docker stop -t 5 %p
 ExecStartPre=-/usr/bin/docker rm %p
 ExecStartPre=/usr/bin/docker pull nsqio/nsq:v0.3.5

--- a/build/test-runner.service
+++ b/build/test-runner.service
@@ -7,6 +7,7 @@ Requires=env-lock.service docker.service nsqd.service
 Restart=always
 User=core
 TimeoutStartSec=0
+RestartSec=5s
 EnvironmentFile=/etc/opsee/bastion-env.sh
 ExecStartPre=-/usr/bin/docker stop -t 5 %p
 ExecStartPre=-/usr/bin/docker rm %p


### PR DESCRIPTION
Set TimeoutStartSec=0 for all units because long docker pulls will cause units to fail.
make env-lock wait until bastion.env is not empty and has r/w
set RestartSec=5s in all units to prevent them from hitting RequestLimit

http://container-solutions.com/running-docker-containers-with-systemd/

We’ve used TimeoutStartSec=0 to turn off timeouts, as the docker pull may take a while.
