### PR TITLE
Fix grpc issues and nsqd tests

### DIFF
--- a/src/github.com/opsee/bastion/checker/common_test.go
+++ b/src/github.com/opsee/bastion/checker/common_test.go
@@ -2,7 +2,9 @@ package checker
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/opsee/bastion/logging"
@@ -134,6 +136,59 @@ func newTestResolver() *testResolver {
 				},
 			},
 		},
+	}
+}
+
+type NsqTopic struct {
+	Topic string
+}
+type NsqChannel struct {
+	Topic   string
+	Channel string
+}
+
+type resetNsqConfig struct {
+	Topics   []NsqTopic
+	Channels []NsqChannel
+}
+
+func resetNsq(host string, qmap resetNsqConfig) {
+	makeRequest := func(u *url.URL) error {
+		client := &http.Client{}
+		r := &http.Request{
+			Method: "POST",
+			URL:    u,
+		}
+		logger.Info("Making request to NSQD: %s", r.URL)
+		resp, err := client.Do(r)
+		defer resp.Body.Close()
+		body, _ := ioutil.ReadAll(resp.Body)
+		logger.Info("Response from NSQD: Code=%d Body=%s", resp.Status, body)
+		return err
+	}
+
+	emptyTopic := func(t string) error {
+		u, _ := url.Parse(fmt.Sprintf("http://%s:4151/topic/empty", host))
+		u.RawQuery = fmt.Sprintf("topic=%s", t)
+		return makeRequest(u)
+	}
+
+	emptyChannel := func(t, c string) error {
+		u, _ := url.Parse(fmt.Sprintf("http://%s:4151/channel/empty", host))
+		u.RawQuery = fmt.Sprintf("topic=%s&channel=%s", t, c)
+		return makeRequest(u)
+	}
+
+	for _, topic := range qmap.Topics {
+		if err := emptyTopic(topic.Topic); err != nil {
+			panic(err)
+		}
+	}
+
+	for _, channel := range qmap.Channels {
+		if err := emptyChannel(channel.Topic, channel.Channel); err != nil {
+			panic(err)
+		}
 	}
 }
 

--- a/src/github.com/opsee/bastion/checker/runner.go
+++ b/src/github.com/opsee/bastion/checker/runner.go
@@ -104,6 +104,7 @@ func NewNSQRunner(runner *Runner, cfg *NSQRunnerConfig) (*NSQRunner, error) {
 			cancel()
 			return err
 		}
+		logger.Debug("NSQRunner handler finished publishing result.")
 
 		return nil
 	}), cfg.MaxHandlers)


### PR DESCRIPTION
This commit makes the invoke() command in the Checker actually safe. It
fixes incorrect assumptions that were made about the way the reflection
stuff works. Also, we now correctly clean up NSQd before and after every
test that uses it. This necessitated a change in build-go to only run
tests serially. We will at some point have to fix this.
