### PR TITLE
Connector needs to start after bastion-etcd, or will fail once

### DIFF
--- a/build/mami.json
+++ b/build/mami.json
@@ -32,11 +32,11 @@
         },
         {
             "type":"systemd",
-            "unit-file":"build/connector.service"
+            "unit-file":"build/bastion-etcd.service"
         },
         {
             "type":"systemd",
-            "unit-file":"build/bastion-etcd.service"
+            "unit-file":"build/connector.service"
         },
         {
             "type":"systemd",


### PR DESCRIPTION
connector.service requires bastion-etcd.service.  So, we copy and run it AFTER bastion-etcd.service.
