### PR TITLE
Retry unhack on failure

### DIFF
--- a/vendor/src/github.com/polds/logrus-papertrail-hook/CONTRIBUTING.md
+++ b/vendor/src/github.com/polds/logrus-papertrail-hook/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+Contributions are welcome! Please submit a PR. Please ensure the tests pass before submitting a PR.

--- a/vendor/src/github.com/polds/logrus-papertrail-hook/LICENSE
+++ b/vendor/src/github.com/polds/logrus-papertrail-hook/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Peter Olds
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/vendor/src/github.com/polds/logrus-papertrail-hook/README.md
+++ b/vendor/src/github.com/polds/logrus-papertrail-hook/README.md
@@ -1,0 +1,34 @@
+# Papertrail Hook for Logrus <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:" /> [![Build Status](https://travis-ci.org/polds/logrus-papertrail-hook.svg)](https://travis-ci.org/polds/logrus-papertrail-hook)&nbsp;[![godoc reference](https://godoc.org/github.com/polds/logrus-papertrail-hook?status.png)](https://godoc.org/gopkg.in/polds/logrus-papertrail-hook.v2)
+
+[Papertrail](https://papertrailapp.com) provides hosted log management. Once stored in Papertrail, you can [group](http://help.papertrailapp.com/kb/how-it-works/groups/) your logs on various dimensions, [search](http://help.papertrailapp.com/kb/how-it-works/search-syntax) them, and trigger [alerts](http://help.papertrailapp.com/kb/how-it-works/alerts).
+
+In most deployments, you'll want to send logs to Papertrail via their [remote_syslog](http://help.papertrailapp.com/kb/configuration/configuring-centralized-logging-from-text-log-files-in-unix/) daemon, which requires no application-specific configuration. This hook is intended for relatively low-volume logging, likely in managed cloud hosting deployments where installing `remote_syslog` is not possible.
+
+## Usage
+
+You can find your Papertrail UDP port on your [Papertrail account page](https://papertrailapp.com/account/destinations). Substitute it below for `YOUR_PAPERTRAIL_UDP_PORT`.
+
+For `YOUR_APP_NAME`, substitute a short string that will readily identify your application or service in the logs.
+
+```go
+import (
+  "log/syslog"
+  "github.com/Sirupsen/logrus"
+  "gopkg.in/polds/logrus-papertrail-hook.v2"
+)
+
+func main() {
+  log       := logrus.New()
+  hook, err := logrus_papertrail.NewPapertrailHook(&logrus_papertrail.Hook{"logs.papertrailapp.com", YOUR_PAPERTRAIL_UDP_PORT, YOUR_HOST_NAME, YOUR_APP_NAME})
+
+  if err == nil {
+    log.Hooks.Add(hook)
+  }
+}
+```
+
+## Changelog
+- [gopkg.in/polds/logrus-papertrail-hook.v1](https://godoc.org/gopkg.in/polds/logrus-papertrail-hook.v1)
+    - Unchanged from split from [logrus](https://github.com/Sirupsen/logrus)
+- [gopkg.in/polds/logrus-papertrail-hook.v2](https://godoc.org/gopkg.in/polds/logrus-papertrail-hook.v2)
+    - Adds support for custom hostnames. Major API change.

--- a/vendor/src/github.com/polds/logrus-papertrail-hook/papertrail.go
+++ b/vendor/src/github.com/polds/logrus-papertrail-hook/papertrail.go
@@ -1,0 +1,62 @@
+package logrus_papertrail
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+)
+
+const (
+	format = "Jan 2 15:04:05"
+)
+
+// PapertrailHook to send logs to a logging service compatible with the Papertrail API.
+type Hook struct {
+	// Connection Details
+	Host string
+	Port int
+
+	// App Details
+	Appname  string
+	Hostname string
+
+	udpConn net.Conn
+}
+
+// NewPapertrailHook creates a hook to be added to an instance of logger.
+func NewPapertrailHook(hook *Hook) (*Hook, error) {
+	var err error
+
+	hook.udpConn, err = net.Dial("udp", fmt.Sprintf("%s:%d", hook.Host, hook.Port))
+	return hook, err
+}
+
+// Fire is called when a log event is fired.
+func (hook *Hook) Fire(entry *logrus.Entry) error {
+	date := time.Now().Format(format)
+	msg, _ := entry.String()
+	payload := fmt.Sprintf("<22> %s %s %s: %s", date, hook.Hostname, hook.Appname, msg)
+
+	bytesWritten, err := hook.udpConn.Write([]byte(payload))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to send log line to Papertrail via UDP. Wrote %d bytes before error: %v", bytesWritten, err)
+		return err
+	}
+
+	return nil
+}
+
+// Levels returns the available logging levels.
+func (hook *Hook) Levels() []logrus.Level {
+	return []logrus.Level{
+		logrus.PanicLevel,
+		logrus.FatalLevel,
+		logrus.ErrorLevel,
+		logrus.WarnLevel,
+		logrus.InfoLevel,
+		logrus.DebugLevel,
+	}
+}

--- a/vendor/src/github.com/polds/logrus-papertrail-hook/papertrail_test.go
+++ b/vendor/src/github.com/polds/logrus-papertrail-hook/papertrail_test.go
@@ -1,0 +1,53 @@
+package logrus_papertrail
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/polds/logrus-papertrail-hook"
+	"github.com/stvp/go-udp-testing"
+)
+
+func TestWritingToUDP(t *testing.T) {
+	port := 16661
+	udp.SetAddr(fmt.Sprintf(":%d", port))
+
+	hook, err := logrus_papertrail.NewPapertrailHook(&logrus_papertrail.Hook{
+		Host:     "localhost",
+		Port:     port,
+		Hostname: "test.local",
+		Appname:  "test",
+	})
+	if err != nil {
+		t.Errorf("Unable to connect to local UDP server.")
+	}
+
+	log := logrus.New()
+	log.Hooks.Add(hook)
+
+	udp.ShouldReceive(t, "foo", func() {
+		log.Info("foo")
+	})
+}
+
+func TestReal(t *testing.T) {
+	port, _ := strconv.Atoi(os.Getenv("PAPERTRAIL_PORT"))
+
+	hook, err := logrus_papertrail.NewPapertrailHook(&logrus_papertrail.Hook{
+		Host:     os.Getenv("PAPERTRAIL_HOST"),
+		Port:     port,
+		Hostname: "appserver",
+		Appname:  "myapp",
+	})
+	if err != nil {
+		t.Errorf("Unable to connect to Papertrail")
+	}
+
+	log := logrus.New()
+	log.Hooks.Add(hook)
+
+	log.Infoln("testing")
+}


### PR DESCRIPTION
Add hacked groups to a buffered channel.  When we reach the unhack state, pull from that channel until there's nothing left.  If we can't unhack a hacked group, add it back to the channel and try again.
