### PR TITLE
Bypass slate if we shouldn't be using it.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM gliderlabs/alpine:3.2
 
 ENV BARTNET_HOST="https://bartnet.in.opsee.com"
 ENV NSQD_HOST="nsqd:4150"
-ENV SLATE_HOST="slate:7000"
+ENV SLATE_HOST=""
 ENV CA_PATH="ca.pem"
 ENV CERT_PATH="cert.pem"
 ENV KEY_PATH="key.pem"

--- a/src/github.com/opsee/bastion/checker/runner.go
+++ b/src/github.com/opsee/bastion/checker/runner.go
@@ -159,12 +159,17 @@ type Runner struct {
 func NewRunner(resolver Resolver) *Runner {
 	dispatcher := NewDispatcher()
 
-	slateUrl := fmt.Sprintf("http://%s/check", os.Getenv("SLATE_HOST"))
-	return &Runner{
-		dispatcher:  dispatcher,
-		resolver:    resolver,
-		slateClient: NewSlateClient(slateUrl),
+	r := &Runner{
+		dispatcher: dispatcher,
+		resolver:   resolver,
 	}
+
+	slateUrl := fmt.Sprintf("http://%s/check", os.Getenv("SLATE_HOST"))
+	if slateUrl != "" {
+		r.slateClient = NewSlateClient(slateUrl)
+	}
+
+	return r
 }
 
 func (r *Runner) resolveRequestTargets(ctx context.Context, check *Check) ([]*Target, error) {
@@ -280,8 +285,7 @@ func (r *Runner) runCheck(ctx context.Context, check *Check, tasks chan *Task, r
 			Error:    responseError,
 		}
 
-		// If we have a responseError, then don't both sending it to slate.
-		if response.Error == "" && len(check.Assertions) > 0 {
+		if response.Error == "" && len(check.Assertions) > 0 && r.slateClient != nil {
 			passing, err = r.slateClient.CheckAssertions(ctx, check, t.Response.Response)
 			if err != nil {
 				log.WithError(err).Error("Could not contact slate.")


### PR DESCRIPTION
Avoid sending checks to slate if there are no assertions as this will only break things. Don't try to use Slate if it's not configured correctly.
