### PR TITLE
Stop attempting to fetch checks if bartnet sends back response with 0 checks.

### DIFF
--- a/src/github.com/opsee/bastion/checker/checker.go
+++ b/src/github.com/opsee/bastion/checker/checker.go
@@ -489,14 +489,6 @@ func (c *Checker) GetExistingChecks(tries int) ([]*schema.Check, error) {
 						goto SLEEP
 					}
 
-					if len(checks.Checks) == 0 {
-						// Consider this a fatal error. If there are legitimately 0 checks, then
-						// the checker doesn't need to startup anyway. If there are 0 checks because
-						// of an error, then same.
-						err = errors.New("Got 0 checks when synchronizing bastion state with Bartnet.")
-						log.WithFields(log.Fields{"service": "checker", "error": err, "response": resp}).Error("Couldn't sychronize checks.")
-						goto SLEEP
-					}
 					log.Debug("Got existing checks ", checks)
 					success = true
 					break
@@ -527,7 +519,6 @@ func (c *Checker) Start() error {
 	}
 
 	log.Info("Getting existing checks")
-	// Now Get existing checks from bartnet
 	existingChecks, err := c.GetExistingChecks(NumCheckSyncRetries)
 	if err != nil {
 		log.WithFields(log.Fields{"service": "checker", "event": "sync checks", "error": err}).Error("failed to sync checks")
@@ -539,6 +530,7 @@ func (c *Checker) Start() error {
 	// Now start and register the GRPC server and allow users to create/edit/etc checks
 	go c.grpcServer.Serve(listen)
 	opsee.RegisterCheckerServer(c.grpcServer, c)
+
 	return nil
 }
 


### PR DESCRIPTION
On first launch: keelhaul calls bartnet to create checks.  Bastion will synchronize checks with bartnet.  This happens prior to bastion launch so checks should get synchronized unless keelhaul fails to create checks via bartnet or the bastion fails to make the request to bartnet.  In the former case no checks will be reported as being created and in the latter, we will retry several times.

On bastion startup: Scheduler is started. GRPC is started.  Then the Bastion synchronizes checks with bartnet.  If the bastion gets a valid response with 0 checks, it now stops trying to synchronize checks because we assume that no checks exist.

While it's possible that a user-created check could be overwritten by check pulled from bartnet during synchronization, it is unlikely given that the check-id would need to be the same for both checks.   
